### PR TITLE
use self.nchannels such that it is defined

### DIFF
--- a/src/audiostretchy/stretch.py
+++ b/src/audiostretchy/stretch.py
@@ -152,7 +152,7 @@ class AudioStretch:
             encoder.set_channels(self.nchannels)
             encoder.set_quality(quality)
             encoder.set_mode(
-                mp3.MODE_STEREO if nchannels == 2 else mp3.MODE_SINGLE_CHANNEL
+                mp3.MODE_STEREO if self.nchannels == 2 else mp3.MODE_SINGLE_CHANNEL
             )
             encoder.write(self.pcm)
         except ImportError:


### PR DESCRIPTION
### **User description**
fixes an error in AudioStretch.save


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed an error in the `save_mp3` method of the `AudioStretch` class by replacing `nchannels` with `self.nchannels`.
- Ensures that the `self.nchannels` attribute is used consistently within the method.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stretch.py</strong><dd><code>Fix undefined variable error in `save_mp3` method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/audiostretchy/stretch.py

<li>Replaced <code>nchannels</code> with <code>self.nchannels</code> in <code>save_mp3</code> method.<br> <li> Ensures <code>self.nchannels</code> is used consistently.<br>


</details>


  </td>
  <td><a href="https://github.com/twardoch/audiostretchy/pull/11/files#diff-5e3786b499a915d333aa991a4e6a594d0fca4409b17e21f87b7cc93621a2688c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

