### PR TITLE
docs: Replace README.md with comprehensive one-page documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,131 +1,329 @@
 # AudioStretchy
 
-AudioStretchy is a Python library and CLI tool that performs high-quality time-stretching of audio files without changing their pitch. It is a Python wrapper around David Bryant’s excellent [audio-stretch C library](https://github.com/dbry/audio-stretch), which implements Time-Domain Harmonic Scaling (TDHS). AudioStretchy uses [Spotify's Pedalboard library](https://github.com/spotify/pedalboard) for robust audio file input/output (WAV, MP3, FLAC, OGG, etc.) and resampling.
+**AudioStretchy is a Python library and command-line interface (CLI) tool designed for high-quality time-stretching of audio files without altering their pitch.**
 
-_Version: (to be updated by release process)_
+It leverages David Bryant’s robust [audio-stretch C library](https://github.com/dbry/audio-stretch), which implements the Time-Domain Harmonic Scaling (TDHS) algorithm, particularly effective for speech. For versatile audio file handling (WAV, MP3, FLAC, OGG, etc.) and resampling, AudioStretchy integrates [Spotify's Pedalboard library](https://github.com/spotify/pedalboard).
+
+## Table of Contents
+
+- [Who is this for?](#who-is-this-for)
+- [Why is it useful?](#why-is-it-useful)
+- [Features](#features)
+- [Demo](#demo)
+- [Installation](#installation)
+    - [Standard Installation](#standard-installation)
+    - [Development Installation](#development-installation)
+- [Usage](#usage)
+    - [Command-Line Interface (CLI)](#command-line-interface-cli)
+    - [Python API](#python-api)
+- [Technical Details](#technical-details)
+    - [How it Works](#how-it-works)
+    - [Core Modules](#core-modules)
+    - [Coding Conventions](#coding-conventions)
+    - [Contributing](#contributing)
+- [License](#license)
+
+## Who is this for?
+
+AudioStretchy is aimed at:
+
+*   **Musicians and Music Producers:** To adjust the tempo of backing tracks, samples, or entire songs.
+*   **Audio Engineers:** For post-production tasks requiring timing adjustments without pitch artifacts.
+*   **Podcast and Video Editors:** To fit voiceovers or audio segments into specific time slots.
+*   **Software Developers:** Who need to integrate audio time-stretching capabilities into their Python applications.
+*   **Researchers and Hobbyists:** Exploring audio processing techniques.
+
+## Why is it useful?
+
+Time-stretching audio without affecting pitch is a common need in audio production. AudioStretchy provides:
+
+*   **High-Quality Results:** The TDHS algorithm is known for producing natural-sounding results, especially with speech.
+*   **Ease of Use:** Simple CLI and Python API make it accessible for various workflows.
+*   **Format Flexibility:** Supports a wide range of common audio formats thanks to Pedalboard.
+*   **Cross-Platform Compatibility:** Works on Windows, macOS, and Linux.
 
 ## Features
 
-- **High-Quality Time Stretching**: Utilizes David Bryant's `audio-stretch` C library (TDHS algorithm), ideal for speech.
-- **Silence-Aware Stretching**: Supports separate stretching ratios for gaps/silence in audio via the `gap_ratio` parameter (Note: current Python wrapper applies this if the C library has internal segmentation logic based on this, or if Python-side segmentation is added in future).
-- **Broad Audio Format Support**: Reads and writes numerous audio formats (WAV, MP3, FLAC, OGG, etc.) using the Pedalboard library.
-- **Resampling**: Supports audio resampling, also via Pedalboard.
-- **Adjustable Parameters**: Fine-tune stretching with parameters like frequency limits for period detection, buffer sizes, and silence thresholds.
-- **Cross-Platform**: Includes pre-compiled C libraries for Windows, macOS (x86_64, arm64), and Linux.
-- **Simple CLI and Python API**.
-
-**Time-Domain Harmonic Scaling (TDHS)** is a method for time-scale modification of speech (or other audio signals), allowing the apparent rate of speech articulation to be changed without affecting the pitch-contour and the time-evolution of the formant structure. TDHS differs from other time-scale modification algorithms in that time-scaling operations are performed in the time domain (not the frequency domain). The `audio-stretch` C library provides a high-quality TDHS implementation.
+*   **High-Quality Time Stretching**: Utilizes David Bryant's `audio-stretch` C library (TDHS algorithm).
+*   **Silence-Aware Stretching**: Supports separate stretching ratios for gaps/silence via the `gap_ratio` parameter (Note: The Python wrapper currently passes this to the C library; however, effective silence-specific stretching relies on the C library's internal segmentation or future Python-side pre-segmentation logic).
+*   **Broad Audio Format Support**: Reads and writes numerous audio formats (WAV, MP3, FLAC, OGG, AIFF, etc.) using the Pedalboard library.
+*   **Resampling**: Supports audio resampling, also via Pedalboard.
+*   **Adjustable Parameters**: Fine-tune stretching with parameters like frequency limits for period detection, buffer sizes, and silence thresholds.
+*   **Cross-Platform**: Includes pre-compiled C libraries for Windows, macOS (x86_64, arm64), and Linux.
+*   **Simple CLI and Python API**.
 
 ## Demo
 
-Below are links to a short audio file (as WAV and MP3), with the same file stretched at 1.2 (20% slower):
+Below are links to a short audio file (as WAV and MP3), with the same file stretched at a ratio of 1.2 (making it 20% slower):
 
-| Input                                                                             | Stretched                                                                                 |
+| Input                                                                             | Stretched (Ratio 1.2)                                                                     |
 | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | [`audio.wav`](https://github.com/twardoch/audiostretchy/raw/main/tests/audio.wav) | [`audio-1.2.wav`](https://github.com/twardoch/audiostretchy/raw/main/tests/audio-1.2.wav) |
 | [`audio.mp3`](https://github.com/twardoch/audiostretchy/raw/main/tests/audio.mp3) | [`audio-1.2.mp3`](https://github.com/twardoch/audiostretchy/raw/main/tests/audio-1.2.mp3) |
 
-
 ## Installation
 
-AudioStretchy includes a C extension that provides the core TDHS algorithm. Pre-compiled wheels are provided for Windows, macOS, and Linux, so installation is typically straightforward:
+### Standard Installation
+
+AudioStretchy includes a C extension that provides the core TDHS algorithm. Pre-compiled wheels are provided for Windows, macOS, and Linux, making installation straightforward via pip:
 
 ```bash
 python3 -m pip install audiostretchy
 ```
-This command installs `audiostretchy` along with its dependencies:
-- `numpy`: For numerical operations.
-- `pedalboard`: For reading/writing various audio formats (WAV, MP3, FLAC, etc.) and for resampling.
 
-**Note on Pedalboard Dependencies:** For `pedalboard` to support a wide range of audio formats, it might rely on system libraries like FFmpeg. If you encounter issues opening or saving specific file types (especially compressed ones like MP3), ensure FFmpeg is installed and accessible in your system's PATH.
-- On **macOS**: `brew install ffmpeg`
-- On **Linux (Debian/Ubuntu)**: `sudo apt-get install ffmpeg`
-- On **Windows**: Download FFmpeg from the [official website](https://ffmpeg.org/download.html) and add its `bin` directory to your PATH.
+This command installs `audiostretchy` along with its key dependencies:
+*   `numpy`: For numerical operations.
+*   `pedalboard`: For reading/writing various audio formats and for resampling.
+*   `fire`: For the command-line interface.
+
+**Note on Pedalboard Dependencies (FFmpeg):**
+For `pedalboard` to support a wide range of audio formats (especially compressed ones like MP3, M4A, OGG), it relies on system libraries like FFmpeg. If you encounter issues opening or saving specific file types, ensure FFmpeg is installed and accessible in your system's PATH.
+
+*   **macOS (using Homebrew):** `brew install ffmpeg`
+*   **Linux (Debian/Ubuntu):** `sudo apt-get install ffmpeg`
+*   **Windows:** Download FFmpeg from the [official website](https://ffmpeg.org/download.html), extract it, and add its `bin` directory to your system's PATH environment variable.
 
 ### Development Installation
 
-To install the development version from the repository:
+To install the development version from the repository for contributing or testing:
+
 ```bash
 git clone https://github.com/twardoch/audiostretchy.git
 cd audiostretchy
-git submodule update --init --recursive # To fetch the C library source
-python3 -m pip install -e .
+git submodule update --init --recursive # To fetch the audio-stretch C library source
+python3 -m pip install -e .[testing] # Installs in editable mode with testing dependencies
 ```
-If you modify the C code in `vendors/stretch/`, you'll need to recompile the library. The CI workflow handles this for official releases. For local development, you'd need a C compiler (GCC/Clang on Linux/macOS, MSVC on Windows) and would manually compile `vendors/stretch/stretch.c` into the appropriate shared library (`_stretch.so`, `_stretch.dylib`, or `_stretch.dll`) and place it in the correct directory under `src/audiostretchy/interface/`.
+
+If you modify the C code in `vendors/stretch/stretch.c`, you will need to recompile the C library. This typically involves:
+1.  Having a C compiler installed (GCC/Clang on Linux/macOS, MSVC on Windows).
+2.  Manually compiling `vendors/stretch/stretch.c` into the appropriate shared library format (`_stretch.so` on Linux, `_stretch.dylib` on macOS, `_stretch.dll` on Windows).
+3.  Placing the compiled library into the correct directory within `src/audiostretchy/interface/` (e.g., `src/audiostretchy/interface/linux/`).
+The CI workflow (`.github/workflows/ci.yaml`) handles this for official releases.
 
 ## Usage
 
-### CLI
+### Command-Line Interface (CLI)
 
-The command-line interface allows you to stretch audio files directly:
+The `audiostretchy` command allows you to stretch audio files directly from your terminal.
+
+**Syntax:**
 ```bash
 audiostretchy INPUT_FILE OUTPUT_FILE [FLAGS]
 ```
 
 **Positional Arguments:**
-- `INPUT_FILE`: Path to the input audio file (e.g., `.wav`, `.mp3`).
-- `OUTPUT_FILE`: Path to save the processed audio file.
+*   `INPUT_FILE`: Path to the input audio file (e.g., `input.wav`, `song.mp3`).
+*   `OUTPUT_FILE`: Path to save the processed audio file (e.g., `output_stretched.wav`).
 
-**Flags (TDHS Parameters):**
--   `-r, --ratio=FLOAT`: The stretch ratio. >1.0 extends audio (slower), <1.0 shortens (faster). Default: `1.0`.
--   `-g, --gap_ratio=FLOAT`: Stretch ratio for silence/gaps. Default: `0.0` (uses main ratio). *Note: Effective use of `gap_ratio` depends on the C library's internal logic or future Python-side segmentation.*
--   `-u, --upper_freq=INT`: Upper frequency limit for period detection (Hz). Default: `333`.
--   `-l, --lower_freq=INT`: Lower frequency limit for period detection (Hz). Default: `55`.
--   `-b, --buffer_ms=FLOAT`: Buffer size in milliseconds for silence detection logic. Default: `25`. *(Note: Primarily for advanced gap handling not fully exposed in basic Python wrapper)*.
--   `-t, --threshold_gap_db=FLOAT`: Silence threshold in dB for gap detection. Default: `-40`. *(Note: Primarily for advanced gap handling not fully exposed in basic Python wrapper)*.
--   `-d, --double_range=BOOL`: Use extended ratio range (0.25-4.0 instead of 0.5-2.0). Default: `False`.
--   `-f, --fast_detection=BOOL`: Enable fast (but potentially lower quality) period detection. Default: `False`.
--   `-n, --normal_detection=BOOL`: Force normal period detection (overrides fast if sample rate is high). Default: `False`.
--   `-s, --sample_rate=INT`: Target sample rate in Hz for resampling (0 to disable). Default: `0`.
+**Optional Flags (TDHS Parameters):**
+*   `-r, --ratio=FLOAT`: The stretch ratio. Values > 1.0 extend audio (slower playback), < 1.0 shorten audio (faster playback). Default: `1.0` (no change).
+*   `-g, --gap_ratio=FLOAT`: Stretch ratio specifically for silence or gaps in the audio. Default: `0.0` (which means use the main `ratio` for gaps). *Note: The underlying C library may use this if it performs internal silence detection, but the Python wrapper does not currently implement pre-segmentation based on this.*
+*   `-u, --upper_freq=INT`: Upper frequency limit for period detection in Hz. Affects how the algorithm identifies fundamental frequencies. Default: `333`.
+*   `-l, --lower_freq=INT`: Lower frequency limit for period detection in Hz. Default: `55`.
+*   `-b, --buffer_ms=FLOAT`: Buffer size in milliseconds, potentially for silence detection logic. Default: `25`. *(Note: Primarily relevant if advanced gap handling is implemented/utilized).*
+*   `-t, --threshold_gap_db=FLOAT`: Silence threshold in dB for gap detection. Default: `-40`. *(Note: Primarily relevant if advanced gap handling is implemented/utilized).*
+*   `-d, --double_range=BOOL`: Use an extended ratio range (0.25-4.0 instead of the default 0.5-2.0). Set to `True` or `False`. Default: `False`.
+*   `-f, --fast_detection=BOOL`: Enable a faster (but potentially lower quality) period detection method. Set to `True` or `False`. Default: `False`.
+*   `-n, --normal_detection=BOOL`: Force normal period detection (this can override fast detection if the sample rate is high, depending on C library logic). Set to `True` or `False`. Default: `False`.
+*   `-s, --sample_rate=INT`: Target sample rate in Hz for resampling the output. If `0` or omitted, the output will have the same sample rate as the input (unless stretching itself inherently changes it, which TDHS does not aim to do for sample rate). Default: `0` (no resampling).
 
 **Example:**
+To make `input.mp3` 20% slower and save it as `output_slow.wav` with a 44100 Hz sample rate:
 ```bash
-audiostretchy input.wav output_stretched.wav -r 1.2 -s 44100
+audiostretchy input.mp3 output_slow.wav --ratio 1.2 --sample_rate 44100
 ```
 
 ### Python API
 
-```python
-from audiostretchy.stretch import AudioStretch, stretch_audio
+AudioStretchy can be used programmatically within your Python scripts.
 
-# Simple function call
+**Simple Function Call:**
+The `stretch_audio` function provides a quick way to process files.
+
+```python
+from audiostretchy.stretch import stretch_audio
+
 stretch_audio(
-    input_path="input.mp3",
-    output_path="output.wav",
-    ratio=0.8,
-    sample_rate=22050, # Resample to 22050 Hz
-    upper_freq=300
+    input_path="path/to/your/input.mp3",
+    output_path="path/to/your/output_stretched.wav",
+    ratio=0.8,  # Make audio 20% faster
+    sample_rate=22050, # Resample output to 22050 Hz
+    upper_freq=300, # Adjust upper frequency for period detection
+    fast_detection=True # Use faster algorithm
 )
 
-# Using the AudioStretch class for more control
+print("Audio stretching complete!")
+```
+
+**Using the `AudioStretch` Class:**
+For more control, or if working with audio data in memory (e.g., from `BytesIO` objects), use the `AudioStretch` class.
+
+```python
+from audiostretchy.stretch import AudioStretch
+from io import BytesIO
+
+# Initialize the processor
 processor = AudioStretch()
+
+# --- Example 1: Processing files ---
 processor.open("input.flac") # Pedalboard handles opening various formats
 
 processor.stretch(
-    ratio=1.1,
-    gap_ratio=1.5,      # Stretch silence even more
+    ratio=1.1,          # Make 10% slower
+    # gap_ratio=1.5,    # Stretch silence even more (see note on gap_ratio effectiveness)
     upper_freq=350,
     lower_freq=60,
     double_range=True   # Allow ratios like 0.25 or 4.0
 )
-processor.resample(target_framerate=48000) # Resample output
 
-processor.save("processed_output.ogg", output_format="ogg") # Save as OGG
+# Optional: Resample the processed audio
+processor.resample(target_framerate=48000)
+
+processor.save("processed_output.ogg") # Pedalboard infers format from extension
+# OR: processor.save("processed_output.custom", output_format="ogg")
+
+
+# --- Example 2: Processing from BytesIO ---
+# Assuming `input_audio_bytes` is a bytes object containing audio data (e.g., read from a stream)
+# and `input_format` is known (e.g., 'wav', 'mp3')
+
+# input_audio_bytes = b"..." # Your audio data
+# input_format = "wav"
+#
+# input_file_like_object = BytesIO(input_audio_bytes)
+# processor.open(file=input_file_like_object, format=input_format) # `format` might be needed if not inferable
+#
+# processor.stretch(ratio=1.5)
+#
+# output_file_like_object = BytesIO()
+# processor.save(file=output_file_like_object, format="mp3") # Specify output format
+#
+# stretched_audio_bytes = output_file_like_object.getvalue()
+# with open("output_from_bytesio.mp3", "wb") as f:
+#     f.write(stretched_audio_bytes)
+
 ```
-The `AudioStretch` class also supports opening from and saving to file-like BytesIO objects by passing the `file` argument to `open()` and `save()`, and optionally `format` if it cannot be inferred.
 
-## Changelog
+## Technical Details
 
-*(To be updated before release)*
-- Core stretching logic remains based on David Bryant's `audio-stretch` C library (TDHS).
-- Audio I/O (WAV, MP3, FLAC, OGG, etc.) and resampling are now handled by the `pedalboard` library.
-- Removed direct dependencies on `pydub`, `pymp3`, `soxr`.
-- Installation streamlined, `[all]` extra removed as `pedalboard` is a core dependency.
-- Updated documentation and examples.
+### How it Works
+
+AudioStretchy operates through several key stages:
+
+1.  **Audio Input/Output & Resampling (via `Pedalboard`):**
+    *   When an input file is provided (e.g., MP3, WAV, FLAC), `pedalboard` is used to decode it into raw audio samples (specifically, a NumPy array of `float32` values). It also reads metadata like sample rate and channel count.
+    *   If resampling is requested, `pedalboard` handles this efficiently.
+    *   After processing, `pedalboard` encodes the modified audio samples back into the desired output format.
+
+2.  **Core Time-Stretching (via `audio-stretch` C library & `TDHSAudioStretch` wrapper):**
+    *   The raw audio samples (float32) obtained from `pedalboard` are converted to 16-bit integers (`int16`), as the C library expects this format. If the audio is stereo, channels are interleaved (L, R, L, R...).
+    *   The `TDHSAudioStretch` class in `src/audiostretchy/interface/tdhs.py` uses `ctypes` to call functions from the pre-compiled `audio-stretch` shared library (e.g., `_stretch.so`, `_stretch.dylib`, `_stretch.dll`).
+    *   The C library implements **Time-Domain Harmonic Scaling (TDHS)**. This algorithm works by:
+        *   Analyzing the input audio signal in the time domain.
+        *   Identifying periodic segments (related to pitch) within the audio.
+        *   To slow down audio (stretch ratio > 1.0), it intelligently repeats these small segments.
+        *   To speed up audio (stretch ratio < 1.0), it removes some of these segments.
+        *   This is done in a way that aims to preserve the harmonic structure and formants, thus maintaining the original pitch and timbre.
+    *   Parameters like `upper_freq` and `lower_freq` guide the C library in its period detection, defining the expected range of fundamental frequencies in the audio.
+    *   Flags like `STRETCH_FAST_FLAG` (for `--fast_detection`) and `STRETCH_DUAL_FLAG` (for `--double_range`) modify the C library's behavior.
+    *   After the C library processes the audio, the resulting `int16` samples are converted back to `float32` for `pedalboard` to handle.
+
+3.  **Python Orchestration (`AudioStretch` class):**
+    *   The `AudioStretch` class in `src/audiostretchy/stretch.py` manages the overall process:
+        *   Initializes and uses `PedalboardAudioFile` for I/O.
+        *   Prepares data for the `TDHSAudioStretch` wrapper (data type conversion, interleaving).
+        *   Calls the `stretch` method of `TDHSAudioStretch`.
+        *   Handles data conversion back from the wrapper.
+        *   Coordinates resampling if requested.
+
+The `gap_ratio` parameter is intended for applying a different stretch ratio to silent portions of the audio. While the Python wrapper passes this to the C library initialization, the current Python implementation of `AudioStretch.stretch()` processes the entire audio with the primary `ratio`. Effective utilization of `gap_ratio` would typically require the Python code to segment the audio into speech/silence parts first (e.g., based on RMS levels and `threshold_gap_db`), and then apply different ratios to these segments, or for the C library to have internal advanced segmentation logic that uses this parameter. The original C CLI application (`main.c` in `dbry/audio-stretch`) contains such segmentation logic, which is not fully replicated in the current Python bindings.
+
+### Core Modules
+
+*   **`src/audiostretchy/__main__.py`:**
+    *   Provides the command-line interface using the `fire` library.
+    *   It calls the `stretch_audio` function from `stretch.py`.
+*   **`src/audiostretchy/stretch.py`:**
+    *   Contains the main `AudioStretch` class that orchestrates the audio processing.
+    *   Implements methods for opening, stretching, resampling, and saving audio.
+    *   Includes the `stretch_audio` convenience function used by the CLI.
+    *   Relies on `pedalboard` for I/O and resampling, and `TDHSAudioStretch` for the core algorithm.
+*   **`src/audiostretchy/interface/tdhs.py`:**
+    *   Defines the `TDHSAudioStretch` class, which is a Python `ctypes` wrapper around the pre-compiled `audio-stretch` C library.
+    *   Loads the shared library (`.so`, `.dylib`, `.dll`) based on the operating system.
+    *   Defines argument types and return types for the C functions (`stretch_init`, `stretch_samples`, `stretch_flush`, etc.).
+*   **`src/audiostretchy/interface/{win,mac,linux}/`:**
+    *   These directories contain the pre-compiled shared C libraries (`_stretch.dll`, `_stretch.dylib`, `_stretch.so`) for different platforms and architectures.
+*   **`vendors/stretch/`:**
+    *   Contains the source code of David Bryant's `audio-stretch` C library as a Git submodule. This is used for compiling the shared libraries.
+
+### Coding Conventions
+
+This project adheres to standard Python coding practices and uses tools to maintain code quality:
+
+*   **Formatting:** Code is formatted using [Black](https://github.com/psf/black).
+*   **Import Sorting:** Imports are sorted using [isort](https://pycqa.github.io/isort/). Configuration is in `.isort.cfg`.
+*   **Linting:** Code is linted using [Flake8](https://flake8.pycqa.org/en/latest/). Configuration is in `pyproject.toml` (`[tool.flake8]`).
+*   **Pre-commit Hooks:** The `.pre-commit-config.yaml` file defines hooks that run these tools automatically before commits, ensuring consistency. This includes checks for trailing whitespace, large files, valid syntax, etc.
+
+### Contributing
+
+Contributions are welcome! If you'd like to contribute, please follow these general guidelines:
+
+1.  **Fork the Repository:** Create your own fork of the `audiostretchy` repository on GitHub.
+2.  **Clone Your Fork:**
+    ```bash
+    git clone https://github.com/YOUR_USERNAME/audiostretchy.git
+    cd audiostretchy
+    git submodule update --init --recursive
+    ```
+3.  **Create a Branch:** Create a new branch for your feature or bug fix:
+    ```bash
+    git checkout -b my-new-feature
+    ```
+4.  **Set Up Development Environment:**
+    *   It's recommended to use a virtual environment:
+        ```bash
+        python3 -m venv venv
+        source venv/bin/activate  # On Windows: venv\Scripts\activate
+        ```
+    *   Install the project in editable mode with testing dependencies:
+        ```bash
+        python3 -m pip install -e .[testing]
+        ```
+    *   Install pre-commit hooks:
+        ```bash
+        pre-commit install
+        ```
+5.  **Make Your Changes:** Implement your feature or bug fix.
+    *   Adhere to the coding conventions (Black, isort, Flake8). The pre-commit hooks will help with this.
+    *   Write tests for any new functionality in the `tests/` directory.
+6.  **Run Tests:** Ensure all tests pass:
+    ```bash
+    pytest
+    ```
+    Check test coverage:
+    ```bash
+    pytest --cov src/audiostretchy --cov-report term-missing
+    ```
+7.  **Commit Your Changes:**
+    ```bash
+    git add .
+    git commit -m "feat: Add new feature X" # Or "fix: Resolve bug Y"
+    ```
+8.  **Push to Your Fork:**
+    ```bash
+    git push origin my-new-feature
+    ```
+9.  **Submit a Pull Request:** Open a pull request from your branch to the `main` branch of the original `twardoch/audiostretchy` repository. Provide a clear description of your changes.
+
+If you plan to modify the C library code in `vendors/stretch/`, you will also need to recompile it for your platform and potentially update the CI workflows if changes are significant.
 
 ## License
 
-- This project's Python wrapper code: Copyright (c) 2023-2024 Adam Twardoch. Licensed under the [BSD-3-Clause license](./LICENSE.txt).
-- Core C library `vendors/stretch/stretch.c`: Copyright (c) David Bryant. Included under its original BSD-style license.
-- Audio I/O and Resampling: Uses [Spotify's Pedalboard library](https://github.com/spotify/pedalboard) (Apache License 2.0). Pedalboard itself may use other libraries with their own licenses (e.g., libsndfile, Rubber Band library).
-- Python code written with assistance from GPT-4.
+*   The Python wrapper code for AudioStretchy (this project) is licensed under the **BSD-3-Clause License**. See [LICENSE.txt](./LICENSE.txt). Copyright (c) 2023-2024 Adam Twardoch.
+*   The core C library `vendors/stretch/stretch.c` is Copyright (c) David Bryant and is included under its original BSD-style license.
+*   Audio I/O and Resampling functionalities are provided by [Spotify's Pedalboard library](https://github.com/spotify/pedalboard), which is licensed under the Apache License 2.0. Pedalboard itself may utilize other libraries with their own respective licenses (e.g., libsndfile, Rubber Band library).
+*   Some Python code may have been written with assistance from AI language models.
+
+_Current Version: (to be updated by release process)_


### PR DESCRIPTION
This commit replaces the existing README.md with a new, highly informative and detailed one-page documentation.

The new README is structured in two main parts:
1. An accessible overview for wider audiences, describing what the tool does, who it's for, why it's useful, how to install it, and how to use it (from CLI and programmatically).
2. A technical deep-dive describing how the code works precisely, core modules, coding conventions, and contribution guidelines.

This addresses the request to create a more thorough and user-friendly documentation for the AudioStretchy project.

## Summary by Sourcery

Replace the existing README with a comprehensive one-page guide that provides an accessible overview, installation and usage instructions, technical deep dive, and contribution guidelines for the AudioStretchy project.

Documentation:
- Rewrite README.md as a structured one-page document with a Table of Contents for easy navigation.
- Add “Who is this for?” and “Why is it useful?” sections to clarify audience and use cases.
- Expand installation instructions into Standard and Development workflows, detailing dependencies and C extension compilation.
- Enhance usage examples with both CLI and Python API demos, including file-based and BytesIO scenarios.
- Introduce a Technical Details section covering architecture, core modules, algorithm workflow, coding conventions, and contributing guidelines.
- Update license information with clear attributions for the Python wrapper, C library, and third-party dependencies.